### PR TITLE
Windows support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Add support for Windows.
 
 ## [0.1.3] - 2019-06-18
 ### Added

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,6 @@
 import { exec } from "child_process";
 import { quote } from "shell-quote";
+import { type } from "os";
 import {
   workspace,
   commands,
@@ -16,16 +17,22 @@ import {
 const projectRoot = workspace.rootPath ? workspace.rootPath : ".";
 
 const gitGrep = (query: string): Promise<QuickPickItem[]> => {
-  const command = quote([
+  let command = quote([
     "git",
     "grep",
     "-H",
     "-n",
     "-i",
     "-I",
+    "--no-color",
     "-e",
     query === "" ? " " : query
   ]);
+
+  if (type() === "Windows_NT") {
+    // shell-quote doesn't work for cmd.exe
+    command = command.replace(/\"/g, '"""').replace(/\'/g, '"');
+  }
 
   return new Promise((resolve, _) => {
     exec(


### PR DESCRIPTION
`shell-quote` doesn't work well for cmd.exe so on windows we need to
escape double quotes properly and replace single quotes with double quotes.

ANSI escape characters also cause problems with the output on windows so
we add the `--no-color` parameter to the git command to fix this.