### PR TITLE
Dynamically recalculate the QuickPickItems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
 - Add support for Windows.
+
+### Changed
+- Call `git grep` on at the user types to prevent QuickPick from falling back
+  to fuzzy matching by default.
 
 ## [0.1.3] - 2019-06-18
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for Windows.
 
 ### Changed
-- Call `git grep` on at the user types to prevent QuickPick from falling back
+- Call `git grep` as the user types to prevent QuickPick from falling back
   to fuzzy matching by default.
 
 ## [0.1.3] - 2019-06-18

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -111,6 +111,10 @@ export function activate(context: ExtensionContext) {
       }
     });
 
+    quickPick.onDidChangeValue(async val => {
+      quickPick.items = await gitGrep(val);
+    });
+
     quickPick.show();
   });
 


### PR DESCRIPTION
The current implementations calls `git grep` once with no query and then
used the default `QuickPick` behaviour to filter the result. This update
dynamically updates the items as the user types. This starts to filter
and then the result list is updated with the grep results when they return.