### PR TITLE
Add -F parameter since regex isn't currently supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
 - Add support for Windows.
+
+### Changed
+- Add `-F` to `git grep` since regex is currently unsupported.
 
 ## [0.1.3] - 2019-06-18
 ### Added

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,6 +25,7 @@ const gitGrep = (query: string): Promise<QuickPickItem[]> => {
     "-i",
     "-I",
     "--no-color",
+    "-F",
     "-e",
     query === "" ? " " : query
   ]);


### PR DESCRIPTION
This way the search strings are interpreted as fixed strings instead of regex.